### PR TITLE
Motoman:  Fix line endings

### DIFF
--- a/Motoman.py
+++ b/Motoman.py
@@ -250,7 +250,7 @@ class RobotPost(object):
         else:
             filesave = folder + progname
         import io
-        fid = open(filesave, "w", newline='\r\n')
+        fid = io.open(filesave, "w", newline='\r\n')
         #fid.write(self.PROG)
         for line in self.PROG:
             fid.write(line.decode('unicode-escape'))

--- a/Motoman.py
+++ b/Motoman.py
@@ -249,11 +249,12 @@ class RobotPost(object):
                 return
         else:
             filesave = folder + progname
-        fid = open(filesave, "w")
+        import io
+        fid = open(filesave, "w", newline='\r\n')
         #fid.write(self.PROG)
         for line in self.PROG:
-            fid.write(line)
-            fid.write('\n')
+            fid.write(line.decode('unicode-escape'))
+            fid.write(u'\n')
         fid.close()
         print('SAVED: %s\n' % filesave) # tell RoboDK the path of the saved file
         self.PROG_FILES.append(filesave)


### PR DESCRIPTION
Motoman programs are required to have Microsoft Windows style line endings.
This ensures that it is the case whatever the platform the script is ran on.

Previously the generated scripts on Linux would be "malformed" for the Motoman controller.