### PR TITLE
Motoman: Fix zero timeout in waitDI

### DIFF
--- a/Motoman.py
+++ b/Motoman.py
@@ -487,7 +487,7 @@ class RobotPost(object):
                 io_value = 'OFF'
         
         # at this point, io_var and io_value must be string values
-        if timeout_ms < 0:
+        if timeout_ms <= 0:
             #WAIT IN#(12)=ON
             self.addline('WAIT %s=%s' % (io_var, io_value))
         else:


### PR DESCRIPTION
The timeout is optional, a zero timeout does not makes much sense because then no timeout should be used at all.