### PR TITLE
Fixed VAL3 simplified angles_2_str indexing

### DIFF
--- a/Staubli_VAL3_simplified.py
+++ b/Staubli_VAL3_simplified.py
@@ -132,7 +132,7 @@ def angles_2_str(angles):
     """Prints a joint target for Staubli VAL3 XML"""
     str = ''    
     for i in range(len(angles)):
-        str = str + ('j%i="%.5f" ' % (i, angles[i]))
+        str = str + ('j%i="%.5f" ' % ((i+1), angles[i]))
     str = str[:-1]
     return str
     


### PR DESCRIPTION
The joint indices for the `.dtx` file should be one based, as in `Staubli_VAL3.py` ln231.
Checked on a Staubli_TX2_90XL, code runs with updated indices.